### PR TITLE
Fix PWD usage

### DIFF
--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     hostname: minio-server
     container_name: minio-server
     env_file:
-      - ${PWD}/src/test/resources/test.env
+      - ./test.env
     environment:
       - MINIO_ACCESS_KEY=admintest
       - MINIO_SECRET_KEY=admintest
@@ -28,7 +28,7 @@ services:
     hostname: store-service
     container_name: store-service
     env_file:
-      - ${PWD}/src/test/resources/test.env
+      - ./test.env
     environment:
       - S3_ENDPOINT=http://minio-server:9000
       - S3_REGION=somewhere


### PR DESCRIPTION
Fixes the use of `${PWD}` for consistency on all platforms (i.e., Windows).

More information can be found here:
https://devops.stackexchange.com/questions/9002/docker-compose-volume-syntax-valid-for-windows-and-linux