### PR TITLE
Lock LDP

### DIFF
--- a/deploy/src/main.ts
+++ b/deploy/src/main.ts
@@ -427,6 +427,13 @@ ds_writer.write({
 				Repo: {
 					crud: {
 						...H_CRUD_DEFAULT,
+						Update: {
+							implies: [
+								'ReadRepo',
+								'UpdateBranch',  // PATCH for updating repo metadata
+								'UpdateLock',  // PATCH for updating repo metadata
+							],
+						},
 						Delete: {
 							implies: [
 								'UpdateRepo',
@@ -446,13 +453,7 @@ ds_writer.write({
 				},
 
 				Lock: {
-					crud: {
-						Create: {},
-						Read: {},
-						Delete: {
-							implies: ['ReadLock'],
-						},
-					},
+					crud: H_CRUD_DEFAULT,
 				},
 
 				AccessControlAny: {

--- a/src/main/kotlin/org/openmbee/flexo/mms/Conditions.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/Conditions.kt
@@ -150,6 +150,11 @@ val LOCK_CRUD_CONDITIONS = REPO_CRUD_CONDITIONS.append {
     }
 }
 
+val LOCK_UPDATE_CONDITIONS = LOCK_CRUD_CONDITIONS.append {
+    // require that the user has the ability to update locks on a lock-level scope
+    permit(Permission.UPDATE_LOCK, Scope.LOCK)
+}
+
 enum class ConditionType {
     INSPECT,
     REQUIRE,

--- a/src/main/kotlin/org/openmbee/flexo/mms/Errors.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/Errors.kt
@@ -81,3 +81,7 @@ open class Http500Excpetion(msg: String): HttpException(msg, HttpStatusCode.Inte
 
 class ServerBugException(msg: String?=null): Http500Excpetion("Possible server implementation bug: ${msg?: "(no description)"}")
 
+
+open class Http501Exception(msg: String): HttpException(msg, HttpStatusCode.NotImplemented)
+
+class NotImplementedException(msg: String): Http501Exception("That action is not yet implemented. $msg")

--- a/src/main/kotlin/org/openmbee/flexo/mms/General.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/General.kt
@@ -1,0 +1,14 @@
+package org.openmbee.flexo.mms
+
+import io.ktor.http.*
+import io.ktor.server.response.*
+import org.openmbee.flexo.mms.server.GenericResponse
+import org.openmbee.flexo.mms.server.LdpDcLayer1Context
+
+suspend fun LdpDcLayer1Context<GenericResponse>.notImplemented() {
+    call.respondText(
+        "That operation is not yet implemented",
+        ContentType.Text.Plain,
+        HttpStatusCode.NotImplemented
+    )
+}

--- a/src/main/kotlin/org/openmbee/flexo/mms/Namespaces.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/Namespaces.kt
@@ -156,6 +156,9 @@ fun prefixesFor(
                                 )
                             }
                         }
+                        else {
+                            add("morl" to MMS_URNS.never)
+                        }
 
                         if(null !== diffId) {
                             with("$this/diffs/$diffId") {
@@ -163,6 +166,9 @@ fun prefixesFor(
                                     "mord" to this,
                                 )
                             }
+                        }
+                        else {
+                            add("morl" to MMS_URNS.never)
                         }
 
                         if(null != lockId) {
@@ -172,6 +178,9 @@ fun prefixesFor(
                                 )
                             }
                         }
+                        else {
+                            add("morl" to MMS_URNS.never)
+                        }
 
                         if(null != commitId) {
                             with("$this/commits/$commitId") {
@@ -180,6 +189,9 @@ fun prefixesFor(
                                     "morc-data" to "$this/data/",
                                 )
                             }
+                        }
+                        else {
+                            add("morl" to MMS_URNS.never)
                         }
                     }
                 }
@@ -202,7 +214,7 @@ fun prefixesFor(
 object MMS {
     private val BASE = SPARQL_PREFIXES["mms"]!!
     val uri = BASE
-    
+
     private fun res(id: String): Resource {
         return ResourceFactory.createResource("${BASE}${id}")
     }
@@ -234,7 +246,7 @@ object MMS {
 
     // object properties
     val id  = ResourceFactory.createProperty(BASE, "id")
-    
+
     private fun prop(id: String): Property {
         return ResourceFactory.createProperty(BASE, id)
     }
@@ -342,6 +354,8 @@ object MMS_OBJECT {
 
 object MMS_URNS {
     private val mms = "urn:mms"
+
+    val never = "$mms:never"
 
     object SUBJECT {
         val aggregator = "$mms:aggregator"

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Branches.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Branches.kt
@@ -3,6 +3,7 @@ package org.openmbee.flexo.mms.routes
 import io.ktor.server.routing.*
 import org.openmbee.flexo.mms.BRANCH_UPDATE_CONDITIONS
 import org.openmbee.flexo.mms.guardedPatch
+import org.openmbee.flexo.mms.notImplemented
 import org.openmbee.flexo.mms.routes.ldp.createBranch
 import org.openmbee.flexo.mms.routes.ldp.getBranches
 import org.openmbee.flexo.mms.routes.ldp.headBranches
@@ -44,6 +45,9 @@ fun Route.crudBranches() {
             // create new branch
             createBranch(usedPost=true)
         }
+
+        // method not allowed
+        otherwiseNotAllowed()
     }
 
     // specific branch
@@ -80,5 +84,13 @@ fun Route.crudBranches() {
                 preconditions = BRANCH_UPDATE_CONDITIONS,
             )
         }
+
+        // delete not yet implemented
+        delete {
+            notImplemented()
+        }
+
+        // method not allowed
+        otherwiseNotAllowed()
     }
 }

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Locks.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Locks.kt
@@ -2,6 +2,7 @@ package org.openmbee.flexo.mms.routes
 
 import io.ktor.server.routing.*
 import org.openmbee.flexo.mms.LOCK_UPDATE_CONDITIONS
+import org.openmbee.flexo.mms.NotImplementedException
 import org.openmbee.flexo.mms.guardedPatch
 import org.openmbee.flexo.mms.reindent
 import org.openmbee.flexo.mms.routes.ldp.createOrReplaceLock
@@ -100,7 +101,8 @@ fun Route.crudLocks() {
 
         // delete a lock
         delete {
-            deleteLock()
+//            deleteLock()
+            throw NotImplementedException("DELETE Lock")
         }
 
         // method not allowed

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Locks.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Locks.kt
@@ -80,7 +80,7 @@ fun Route.crudLocks() {
                 // enforce preconditions if present
                 appendPreconditions { values ->
                     """
-                        graph m-graph:Cluster {
+                        graph mor-graph:Metadata {
                             morl: mms:etag ?__mms_etag .
                             
                             ${values.reindent(6)}
@@ -93,7 +93,7 @@ fun Route.crudLocks() {
             guardedPatch(
                 updateRequest = it,
                 objectKey = "morl",
-                graph = "m-graph:Cluster",
+                graph = "mor-graph:Metadata",
                 preconditions = localConditions,
             )
         }

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockWrite.kt
@@ -6,6 +6,7 @@ import org.apache.jena.vocabulary.RDF
 import org.openmbee.flexo.mms.*
 import org.openmbee.flexo.mms.server.LdpDcLayer1Context
 import org.openmbee.flexo.mms.server.LdpMutateResponse
+import org.openmbee.flexo.mms.server.LdpPatchResponse
 
 
 // require that the given lock does not exist (before attempting to create it)

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/LockWrite.kt
@@ -181,7 +181,7 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
 
         // resource is being replaced
         if(replaceExisting) {
-            // require that the user has the ability to create locks on a repo-level scope
+            // require that the user has the ability to update locks on a repo-level scope
             permit(Permission.UPDATE_LOCK, Scope.REPO)
         }
         // resource is being created

--- a/src/test/kotlin/org/openmbee/flexo/mms/BranchUpdate.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/BranchUpdate.kt
@@ -1,6 +1,7 @@
 package org.openmbee.flexo.mms
 
 
+import io.ktor.http.*
 import org.apache.jena.sparql.vocabulary.FOAF
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
@@ -13,14 +14,18 @@ class BranchUpdate : RefAny() {
 
             withTest {
                 httpPatch(demoBranchPath) {
-                    setSparqlUpdateBody(withAllTestPrefixes("""
+                    setSparqlUpdateBody(
+                        withAllTestPrefixes(
+                            """
                         insert {
                             <> foaf:homepage <https://www.openmbee.org/> .
                         }
                         where {
                             <> dct:title "$demoBranchName"@en .
                         }
-                    """.trimIndent()))
+                    """.trimIndent()
+                        )
+                    )
                 }.apply {
                     response includesTriples {
                         subject(localIri(demoBranchPath)) {
@@ -33,6 +38,32 @@ class BranchUpdate : RefAny() {
                         }
                     }
                 }
+            }
+        }
+
+        "all branches rejects other methods" {
+            createBranch(demoRepoPath, "master", demoBranchId, demoBranchName)
+
+            withTest {
+                onlyAllowsMethods("$demoRepoPath/branches", setOf(
+                    HttpMethod.Head,
+                    HttpMethod.Get,
+                    HttpMethod.Post,
+                ))
+            }
+        }
+
+        "branch rejects other methods" {
+            createBranch(demoRepoPath, "master", demoBranchId, demoBranchName)
+
+            withTest {
+                onlyAllowsMethods(demoBranchPath, setOf(
+                    HttpMethod.Head,
+                    HttpMethod.Get,
+                    HttpMethod.Put,
+                    HttpMethod.Patch,
+                    HttpMethod.Delete,
+                ))
             }
         }
     }

--- a/src/test/kotlin/org/openmbee/flexo/mms/LockAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/LockAny.kt
@@ -11,13 +11,13 @@ import org.openmbee.flexo.mms.util.startsWith
 import org.slf4j.LoggerFactory
 
 // validates response triples for a lock
-fun TriplesAsserter.validateLockTriples(lockId: String, etag: String) {
+fun TriplesAsserter.validateLockTriples(lockId: String, etag: String?=null) {
     // lock triples
     subjectTerse("mor-lock:$lockId") {
         exclusivelyHas(
             RDF.type exactly MMS.Lock,
             MMS.id exactly lockId,
-            MMS.etag exactly etag,
+            if(etag != null) MMS.etag exactly etag else MMS.etag startsWith "",
             MMS.commit startsWith model.expandPrefix("mor-commit:").iri,
             MMS.snapshot startsWith model.expandPrefix("mor-snapshot:Model.").iri,
             MMS.createdBy exactly model.expandPrefix("mu:").iri,

--- a/src/test/kotlin/org/openmbee/flexo/mms/LockAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/LockAny.kt
@@ -4,14 +4,15 @@ import io.kotest.matchers.string.shouldNotBeBlank
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.apache.jena.vocabulary.RDF
-import org.openmbee.flexo.mms.util.TriplesAsserter
-import org.openmbee.flexo.mms.util.exactly
-import org.openmbee.flexo.mms.util.iri
-import org.openmbee.flexo.mms.util.startsWith
+import org.openmbee.flexo.mms.util.*
 import org.slf4j.LoggerFactory
 
 // validates response triples for a lock
-fun TriplesAsserter.validateLockTriples(lockId: String, etag: String?=null) {
+fun TriplesAsserter.validateLockTriples(
+    lockId: String,
+    etag: String?=null,
+    extraPatterns: List<PairPattern> = listOf()
+) {
     // lock triples
     subjectTerse("mor-lock:$lockId") {
         exclusivelyHas(
@@ -21,6 +22,7 @@ fun TriplesAsserter.validateLockTriples(lockId: String, etag: String?=null) {
             MMS.commit startsWith model.expandPrefix("mor-commit:").iri,
             MMS.snapshot startsWith model.expandPrefix("mor-snapshot:Model.").iri,
             MMS.createdBy exactly model.expandPrefix("mu:").iri,
+            *extraPatterns.toTypedArray(),
         )
     }
 }

--- a/src/test/kotlin/org/openmbee/flexo/mms/LockLdpDc.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/LockLdpDc.kt
@@ -21,6 +21,8 @@ class LockLdpDc : LockAny() {
 //                // validate
 //                validateCreatedLockTriples(demoLockId, etag, demoOrgPath)
 //            }
+
+            patch()
         }
     }
 }

--- a/src/test/kotlin/org/openmbee/flexo/mms/LockRead.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/LockRead.kt
@@ -3,6 +3,7 @@ package org.openmbee.flexo.mms
 
 import io.kotest.matchers.shouldBe
 import io.ktor.http.*
+import io.ktor.server.request.*
 import org.openmbee.flexo.mms.util.*
 
 class LockRead : LockAny() {
@@ -15,7 +16,12 @@ class LockRead : LockAny() {
         ).forEach { method ->
             "$method non-existent lock" {
                 withTest {
-                    httpRequest(HttpMethod(method.uppercase()), demoLockPath) {}.apply {
+                    httpRequest(HttpMethod(method.uppercase()), demoLockPath) {
+                        // PATCH request
+                        if(method == "patch") {
+                            addHeader("Content-Type", RdfContentTypes.Turtle.toString())
+                        }
+                    }.apply {
                         response shouldHaveStatus HttpStatusCode.NotFound
                     }
                 }

--- a/src/test/kotlin/org/openmbee/flexo/mms/LockRead.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/LockRead.kt
@@ -12,7 +12,7 @@ class LockRead : LockAny() {
             "head",
             "get",
             "patch",
-            "delete",
+//            "delete",
         ).forEach { method ->
             "$method non-existent lock" {
                 withTest {

--- a/src/test/kotlin/org/openmbee/flexo/mms/LockWrite.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/LockWrite.kt
@@ -1,0 +1,24 @@
+package org.openmbee.flexo.mms
+
+import io.kotest.matchers.shouldBe
+import io.ktor.http.*
+import org.openmbee.flexo.mms.util.*
+
+
+class LockWrite : LockAny() {
+    init {
+        "patch lock" {
+            createLock(demoRepoPath, masterBranchPath, demoLockId)
+
+            withTest {
+                httpPatch(demoLockPath) {
+                    setTurtleBody(withAllTestPrefixes("""
+                        <> rdfs:comment "foo" .
+                    """.trimIndent()))
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds PATCH for locks/{lockId} in order to update a lock's metadata.

It also adds previously missing HEAD and GET ops for the "all locks" LDP endpoint.