### PR TITLE
Feat/artifact store metadataless tests

### DIFF
--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/Artifacts.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/Artifacts.kt
@@ -42,7 +42,7 @@ fun Route.storeArtifacts() {
     }
 
     // specific artifact
-    storageAbstractionResource("$ARTIFACTS_PATH/store/{artifactId}") {
+    storageAbstractionResource("$ARTIFACTS_PATH/{artifactId}") {
         beforeEach = {
             parsePathParams {
                 org()

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -106,9 +106,13 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
             auth(Permission.READ_ARTIFACT.scope.id, ARTIFACT_QUERY_CONDITIONS)
 
             // provide artifact bind pattern
-            graph("mor-graph:Artifacts") {
-                raw(SPARQL_BIND_ARTIFACT)
-            }
+            raw("""
+                optional{
+                    graph mor-graph:Artifacts {
+                        $SPARQL_BIND_ARTIFACT
+                    }
+                }
+            """)
             raw(permittedActionSparqlBgp(Permission.READ_ARTIFACT, Scope.REPO))
         }
     }

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -155,6 +155,9 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
             ZipOutputStream(this).use { stream ->
                 // each artifact
                 for (artifactResource in model.listSubjects()) {
+                    if (artifactResource.toString().startsWith("urn:mms:auth")){
+                        continue
+                    }
                     // decode artifact
                     val decoded = decodeArtifact(artifactResource)
 

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -101,6 +101,7 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
             graph("mor-graph:Artifacts") {
                 raw(SPARQL_BIND_ARTIFACT)
             }
+            raw(permittedActionSparqlBgp(Permission.READ_ARTIFACT, Scope.REPO))
         }
     }
 

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -164,7 +164,7 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
         // Return 204 if there are no artifacts
         var count = 0
         for (artifactResource in model.listSubjects()) {
-            if (artifactResource.uri.contains(MMS_URNS.SUBJECT.auth)){
+            if (artifactResource.uri.startsWith(MMS_URNS.SUBJECT.auth)){
                 continue
             }
             count += 1
@@ -173,7 +173,7 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
 
         // If there are no artifacts (auth triple doesn't count as one)
         if (count == 0) {
-            return call.respond(HttpStatusCode.NoContent, "")
+            return call.respond(HttpStatusCode.NoContent)
         }
 
 
@@ -182,14 +182,13 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
             ZipOutputStream(this).use { stream ->
                 // each artifact
                 for (artifactResource in model.listSubjects()) {
-                    if (artifactResource.uri.contains(MMS_URNS.SUBJECT.auth)){
+                    if (artifactResource.uri.startsWith(MMS_URNS.SUBJECT.auth)){
                         continue
                     }
                     // decode artifact
                     val decoded = decodeArtifact(artifactResource)
 
                     // create zip entry - can't use artifactResource.localName, it drops number characters from beginning of URI
-                    // TODO why is this a cc file - figure out where the default is set and how to override
                     val entry = ZipEntry(artifactResource.toString().split("/").last()+"."+decoded.extension)
 
                     // open the entry

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -159,7 +159,7 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
             ZipOutputStream(this).use { stream ->
                 // each artifact
                 for (artifactResource in model.listSubjects()) {
-                    if (artifactResource.toString().startsWith("urn:mms:auth")){
+                    if (artifactResource.uri.contains(MMS_URNS.SUBJECT.auth)){
                         continue
                     }
                     // decode artifact

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactStoreRead.kt
@@ -165,8 +165,8 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
                     // decode artifact
                     val decoded = decodeArtifact(artifactResource)
 
-                    // create zip entry
-                    val entry = ZipEntry(artifactResource.localName+"."+decoded.extension)
+                    // create zip entry - can't use artifactResource.localName, it drops number characters from beginning of URI
+                    val entry = ZipEntry(artifactResource.toString().split("/").last()+"."+decoded.extension)
 
                     // open the entry
                     stream.putNextEntry(entry)

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
@@ -38,7 +38,6 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
             }
             setBody(object : OutgoingContent.WriteChannelContent() {
                 override val contentType = call.request.contentType()
-                override val contentLength = call.request.contentLength() ?: 0L //TODO make it so client isn't required to send this
                 override suspend fun writeTo(channel: ByteWriteChannel) {
                     call.request.receiveChannel().copyTo(channel)
                 }

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
@@ -136,7 +136,7 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
     call.response.headers.append(HttpHeaders.Location, artifactIri)
 
     // Can't get just the content-type without the parameter, need to parse manually
-    call.response.headers.append(HttpHeaders.ContentType, call.request.contentType().toString().split(";")[0])
+    call.response.headers.append(HttpHeaders.ContentType, call.request.contentType().withoutParameters().toString())
 
 //    // response in the requested format
 //    call.respondText(constructModel.stringify(), RdfContentTypes.Turtle, HttpStatusCode.Created)

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/store/ArtifactWrite.kt
@@ -136,6 +136,9 @@ suspend fun<TRequestContext: GenericRequest> Layer1Context<TRequestContext, Stor
     // set location header
     call.response.headers.append(HttpHeaders.Location, artifactIri)
 
+    // Can't get just the content-type without the parameter, need to parse manually
+    call.response.headers.append(HttpHeaders.ContentType, call.request.contentType().toString().split(";")[0])
+
 //    // response in the requested format
 //    call.respondText(constructModel.stringify(), RdfContentTypes.Turtle, HttpStatusCode.Created)
 

--- a/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
@@ -4,7 +4,6 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.testing.*
 import org.openmbee.flexo.mms.util.*
 import org.slf4j.LoggerFactory
@@ -165,7 +164,6 @@ open class ArtifactAny : RefAny() {
             }
         }
 
-        // TODO: the URI test - not an option in ArtifactWrite
         "get an artifact by id - URI" {
             withTest{
                 httpPost("$artifactsPath/store") {

--- a/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
@@ -1,6 +1,7 @@
 package org.openmbee.flexo.mms
 
 import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldContain
@@ -28,7 +29,7 @@ open class ArtifactAny : RefAny() {
                     setBody("foo")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-                    response.headers[HttpHeaders.Location] shouldContain "${ROOT_CONTEXT}$artifactsPath/"
+                    response.headers[HttpHeaders.Location] shouldContain localIri(artifactsPath)
                     response.contentType() shouldBe ContentType.Text.Plain
                 }
             }
@@ -43,7 +44,7 @@ open class ArtifactAny : RefAny() {
                     setBody("foo")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-                    response.headers[HttpHeaders.Location] shouldContain "${ROOT_CONTEXT}$artifactsPath/"
+                    response.headers[HttpHeaders.Location] shouldContain localIri(artifactsPath)
                     response.contentType() shouldBe ContentType.Text.Plain
                 }
             }
@@ -54,7 +55,7 @@ open class ArtifactAny : RefAny() {
                 httpGet("$artifactsPath/store") {
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.NoContent
-                    response.content.shouldBeEmpty()
+                    response.content.shouldBeNull()
                 }
             }
         }
@@ -110,7 +111,7 @@ open class ArtifactAny : RefAny() {
                     setBody("foo")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-                    response.headers[HttpHeaders.Location] shouldContain "${ROOT_CONTEXT}$artifactsPath/"
+                    response.headers[HttpHeaders.Location] shouldContain localIri(artifactsPath)
 
                     val uri = getLocation(response.headers[HttpHeaders.Location].toString())
                     httpGet(uri) {
@@ -130,7 +131,7 @@ open class ArtifactAny : RefAny() {
                     setBody("foo".toByteArray())
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-                    response.headers[HttpHeaders.Location] shouldContain "${ROOT_CONTEXT}$artifactsPath/"
+                    response.headers[HttpHeaders.Location] shouldContain localIri(artifactsPath)
 
                     val uri = getLocation(response.headers[HttpHeaders.Location].toString())
                     httpGet(uri) {
@@ -150,7 +151,7 @@ open class ArtifactAny : RefAny() {
                     setBody("<http://openmbee.org> <http://openmbee.org> <http://openmbee.org> .")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-                    response.headers[HttpHeaders.Location] shouldContain "${ROOT_CONTEXT}$artifactsPath/"
+                    response.headers[HttpHeaders.Location] shouldContain localIri(artifactsPath)
 
                     val uri = getLocation(response.headers[HttpHeaders.Location].toString())
                     httpGet(uri) {
@@ -171,7 +172,7 @@ open class ArtifactAny : RefAny() {
                     setBody("foo")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-                    response.headers[HttpHeaders.Location] shouldContain "${ROOT_CONTEXT}$artifactsPath/"
+                    response.headers[HttpHeaders.Location] shouldContain localIri(artifactsPath)
 
                     val uri = getLocation(response.headers[HttpHeaders.Location].toString())
                     onlyAllowsMethods(

--- a/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
@@ -47,7 +47,6 @@ open class ArtifactAny : RefAny() {
             }
         }
 
-        // Doesn't work since there are no artifacts and the query checks that the artifacts exist
         "get all artifacts empty" {
             withTest{
                 httpGet("$artifactsPath/store") {
@@ -240,6 +239,9 @@ open class ArtifactAny : RefAny() {
     }
 }
 
+/**
+ * Reads all files in a zip file and returns map of filename to file contents
+ */
 fun readZipContents(zipBytes: ByteArray): Map<String, String> {
     val contents = mutableMapOf<String, String>()
     ZipInputStream(ByteArrayInputStream(zipBytes)).use { zipInputStream ->

--- a/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
@@ -14,7 +14,7 @@ import java.util.zip.ZipInputStream
 open class ArtifactAny : RefAny() {
     override val logger = LoggerFactory.getLogger(LockAny::class.java)
 
-    val artifactsPath = "$demoRepoPath/artifacts"   //orgs/open-mbee/repos/new-repo/artifacts
+    val artifactsPath = "$demoRepoPath/artifacts"
 
 
     init {

--- a/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
@@ -1,5 +1,8 @@
 package org.openmbee.flexo.mms
 
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldMatch
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import org.openmbee.flexo.mms.util.*
@@ -9,7 +12,7 @@ import org.slf4j.LoggerFactory
 open class ArtifactAny : RefAny() {
     override val logger = LoggerFactory.getLogger(LockAny::class.java)
 
-    val artifactsPath = "$demoRepoPath/artifacts"
+    val artifactsPath = "$demoRepoPath/artifacts"   //orgs/open-mbee/repos/new-repo/artifacts
 
 
     init {
@@ -17,15 +20,186 @@ open class ArtifactAny : RefAny() {
             withTest {
                 httpPost("$artifactsPath/store") {
                     addHeader("Content-Type", "text/plain")
-                    addHeader("Content-Length", "3")
                     setBody("foo")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
-//                    response.headers["Link"] shouldMatch "artifactsPath".toRegex()
-//                    response.contentType() shouldBe ContentType.Text.Plain
-//                    response shouldHaveContent "foo"
+                    response.headers["Location"] shouldContain artifactsPath
+                    response.contentType() shouldBe ContentType.Text.Plain
+                    //response shouldHaveContent "foo"      //Don't think this is right - shouldn't it be the id?
+                }
+            }
+        }
+
+        /*
+        Need tests for more posting a specific artifact in different formats, getting all artifacts,
+        getting a specific artifact given an id (? location?)
+         */
+
+        //set a content-type with parameters (like utf-8 on text/plain) and assert that parameters have been removed on returned content type
+        //Param only applies
+        "post artifact text/plain with parameter" {
+            withTest{
+                httpPost("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain; charset=utf-8")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Created
+                    response.headers["Location"] shouldContain artifactsPath
+                    response.contentType() shouldBe ContentType.Text.Plain
+                }
+            }
+        }
+
+        "get all artifacts empty" {
+            withTest{
+                httpGet("$artifactsPath/store") {
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.OK
+                    // Get the rest of the conditions in here later
+                }
+            }
+        }
+
+        /**
+         * Add test here for getting an artifact when there's (2+) artifacts to get
+         */
+
+        // Not used http methods that should fail
+        "put an artifact failing" {
+            withTest{
+                httpPut("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.MethodNotAllowed
+                }
+            }
+        }
+
+        "patch an artifact failing" {
+            withTest{
+                httpPatch("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.MethodNotAllowed
+                }
+            }
+        }
+
+        "head of an artifact failing" {
+            withTest{
+                httpHead("$artifactsPath/store") {
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.MethodNotAllowed
+                }
+            }
+        }
+
+        /*********************************************
+        /artifacts/store/{id} route
+        *********************************************/
+
+        "get an artifact by id - text" {
+            withTest{
+                httpPost("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Created
+                    response.headers["Location"] shouldContain artifactsPath
+
+                    val uri = "$artifactsPath/store/${response.headers["Location"]?.split("/")?.last()}"
+                    httpGet(uri) {
+                    }.apply {
+                        response shouldHaveStatus HttpStatusCode.OK
+                        response.contentType() shouldBe ContentType.Text.Plain
+                        response shouldHaveContent "foo"
+                    }
+                }
+            }
+        }
+
+        // Tried this and pdf since for some reason I saw that was binary - not working, same as above
+        // TODO: this isn't necessarily needed - I want to see if it's an xstring - ArtifactStoreRead.kt, line 77
+        "get an artifact by id - BINARY?" {
+            withTest{
+                httpPost("$artifactsPath/store") {
+                    addHeader("Content-Type", "application/octet-stream")
+                    setBody("foo".toByteArray())
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Created
+                    response.headers["Location"] shouldContain artifactsPath
+
+                    val uri = "$artifactsPath/store/${response.headers["Location"]?.split("/")?.last()}"
+                    httpGet(uri) {
+                    }.apply {
+                        response shouldHaveStatus HttpStatusCode.OK
+                        response.contentType() shouldBe ContentType.Text.Plain
+                        response shouldHaveContent "foo"
+                    }
+                }
+            }
+        }
+
+        // TODO: the URI test - needs work for that in the backend
+
+        // Copy the above one for head, and test get for URI and Binary types of bodies - return when
+        // statement in ArtifactStoreRead.kt
+
+        "put getting an artifact failing" {
+            withTest{
+                httpPost("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Created
+                    response.headers["Location"] shouldContain artifactsPath
+
+                    val uri = "$artifactsPath/store/${response.headers["Location"]?.split("/")?.last()}"
+                    httpPut(uri) {
+                    }.apply {
+                        response shouldHaveStatus HttpStatusCode.MethodNotAllowed
+                    }
+                }
+            }
+        }
+
+        "patch getting an artifact failing" {
+            withTest{
+                httpPost("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Created
+                    response.headers["Location"] shouldContain artifactsPath
+
+                    val uri = "$artifactsPath/store/${response.headers["Location"]?.split("/")?.last()}"
+                    httpPatch(uri) {
+                    }.apply {
+                        response shouldHaveStatus HttpStatusCode.MethodNotAllowed
+                    }
+                }
+            }
+        }
+
+        "post an artifact failing" {
+            withTest{
+                httpPost("$artifactsPath/store") {
+                    addHeader("Content-Type", "text/plain")
+                    setBody("foo")
+                }.apply {
+                    response shouldHaveStatus HttpStatusCode.Created
+                    response.headers["Location"] shouldContain artifactsPath
+
+                    val uri = "$artifactsPath/store/${response.headers["Location"]?.split("/")?.last()}"
+                    httpPost(uri) {
+                    }.apply {
+                        response shouldHaveStatus HttpStatusCode.MethodNotAllowed
+                    }
                 }
             }
         }
     }
 }
+

--- a/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/ArtifactAny.kt
@@ -1,5 +1,6 @@
 package org.openmbee.flexo.mms
 
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.http.*
@@ -58,9 +59,6 @@ open class ArtifactAny : RefAny() {
             }
         }
 
-        /**
-         * Add test here for getting an artifact when there's (2+) artifacts to get
-         */
 
         "get all artifacts two artifacts" {
             withTest{
@@ -171,9 +169,8 @@ open class ArtifactAny : RefAny() {
         "get an artifact by id - URI" {
             withTest{
                 httpPost("$artifactsPath/store") {
-                    addHeader("Content-Type", "test/plain")
-//                    addHeader("Application", "")
-                    setBody("foo")
+                    addHeader("Content-Type", "text/turtle")
+                    setBody("<http://openmbee.org> <http://openmbee.org> <http://openmbee.org> .")
                 }.apply {
                     response shouldHaveStatus HttpStatusCode.Created
                     response.headers["Location"] shouldContain artifactsPath
@@ -182,8 +179,8 @@ open class ArtifactAny : RefAny() {
                     httpGet(uri) {
                     }.apply {
                         response shouldHaveStatus HttpStatusCode.OK
-                        response.contentType() shouldBe ContentType.Application.OctetStream
-                        response shouldHaveContent "foo"
+                        response.contentType().toString() shouldBeEqual "text/turtle"
+                        response shouldHaveContent "<http://openmbee.org> <http://openmbee.org> <http://openmbee.org> ."
                     }
                 }
             }

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - 3030:3030
 
   minio-server:
-    image: minio/minio:RELEASE.2022-05-26T05-48-41Z.hotfix.15f13935a
+    image: quay.io/minio/minio
     hostname: minio-server
     container_name: minio-server
     env_file:
@@ -31,7 +31,7 @@ services:
       - ./test.env
     environment:
       - S3_ENDPOINT=http://minio-server:9000
-      - S3_REGION=somewhere
+      - S3_REGION=us-west-1
       - AWS_ACCESS_KEY_ID=admintest
       - AWS_SECRET_ACCESS_KEY=admintest
     depends_on:


### PR DESCRIPTION
Added tests in ArtifactAny.kt to test all artifact functionality for the below routes: 

`/orgs/{orgId}/repos/{repoId}/artifacts/store`
Tested putting an artifact with/without content-type parameter, getting all artifacts (empty and with 2 artifacts to get), and tested that unused http methods failed.

`/orgs/{orgId}/repos/{repoId}/artifacts/store/{artifactId}`
Tested getting an artifact that's binary, text, or a URI from the store service, and tested that unused http methods failed.
