### PR TITLE
Minimize update string 

### DIFF
--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/gsp/ModelLoad.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/gsp/ModelLoad.kt
@@ -342,11 +342,10 @@ suspend fun GspLayer1Context<GspMutateResponse>.loadModel() {
     // still greater than safe maximum
     if (call.application.maximumLiteralSizeKib?.let { patchString.length/1024f > it } == true) {
         log("Compressed patch string still too large")
-
         // TODO: store as delete and insert graphs...
-
         // otherwise, just give up
         patchString = "<urn:mms:omitted> <urn:mms:too-large> <urn:mms:to-handle> ."
+        patchStringDatatype = MMS_DATATYPE.sparql
     }
     log("Prepared commit update string:")
     executeSparqlUpdate(commitUpdateString) {

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/gsp/ModelLoad.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/gsp/ModelLoad.kt
@@ -317,6 +317,7 @@ suspend fun GspLayer1Context<GspMutateResponse>.loadModel() {
         """
     )
     //create patch string to get from previous commit to loaded graph
+    // ?__mms_model will be replaced with graph to apply to during branch/lock graph materialization
     var patchString = """
         delete data {
             graph ?__mms_model {

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
@@ -124,6 +124,7 @@ fun Route.commitModel() {
             var patchStringDatatype = MMS_DATATYPE.sparql
 
             // approximate patch string size in bytes by assuming each character is 1 byte
+            // TODO this is producing an empty string, need to debug/find alternative to store
             if (application.gzipLiteralsLargerThanKib?.let { patchString.length/1024f > it } == true) {
                 compressStringLiteral(patchString)?.let {
                     patchString = it

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
@@ -129,6 +129,13 @@ fun Route.commitModel() {
                     patchStringDatatype = MMS_DATATYPE.sparqlGz
                 }
             }
+            // still greater than safe maximum
+            if (call.application.maximumLiteralSizeKib?.let { patchString.length/1024f > it } == true) {
+                log("Compressed patch string still too large")
+                // otherwise, just give up
+                patchString = "<urn:mms:omitted> <urn:mms:too-large> <urn:mms:to-handle> ."
+                patchStringDatatype = MMS_DATATYPE.sparql
+            }
 
             executeSparqlUpdate(commitUpdateString) {
                 val p = prefixes
@@ -140,9 +147,9 @@ fun Route.commitModel() {
                 )
 
                 datatyped(
-                    "_updateBody" to (requestContext.update to MMS_DATATYPE.sparql),
+                    "_updateBody" to ("" to MMS_DATATYPE.sparql), //find some other way to store if needed
                     "_patchString" to (patchString to patchStringDatatype),
-                    "_whereString" to ("" to MMS_DATATYPE.sparql), //not needed?
+                    "_whereString" to ("" to MMS_DATATYPE.sparql),
                 )
 
                 literal(

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
@@ -111,7 +111,8 @@ fun Route.commitModel() {
                     else -> throw UpdateOperationNotAllowedException("SPARQL ${update.javaClass.simpleName} not allowed here")
                 }
             }
-            // this is used for reconstructing graph from previous commit, ?__mms_model should be replaced with graph to apply to
+            // this is used for reconstructing graph from previous commit,
+            // ?__mms_model will be replaced with graph to apply to during branch/lock graph materialization
             var patchString = clientPrefixes.map {
                 entry -> "PREFIX ${entry.key}: <${entry.value}>"
             }.joinToString("\n")

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
@@ -119,7 +119,7 @@ fun Route.commitModel() {
 
             // this is used for reconstructing graph from previous commit,
             // ?__mms_model will be replaced with graph to apply to during branch/lock graph materialization
-            var patchString = sparqlUpdateAst.prefixMapping.nsPrefixMap.entries.joinToString("\n") {
+            var patchString = sparqlUpdateAst.prefixMapping.nsPrefixMap.minus(prefixes.map.keys).entries.joinToString("\n") {
                 "PREFIX ${it.key}: <${it.value}>"
             } + "\n\n" + updates.joinToString(";\n")
 

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/sparql/ModelCommit.kt
@@ -119,7 +119,7 @@ fun Route.commitModel() {
 
             // this is used for reconstructing graph from previous commit,
             // ?__mms_model will be replaced with graph to apply to during branch/lock graph materialization
-            var patchString = mergedPrefixMap.entries.joinToString("\n") {
+            var patchString = sparqlUpdateAst.prefixMapping.nsPrefixMap.entries.joinToString("\n") {
                 "PREFIX ${it.key}: <${it.value}>"
             } + "\n\n" + updates.joinToString(";\n")
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -6,13 +6,13 @@
             <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
-    <root level="TRACE">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT" />
     </root>
     <logger name="org.apache.jena.sparql" level="WARN"/>
     <logger name="org.eclipse.jetty" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
-    <logger name="io.ktor.server" level="TRACE"/>
+    <logger name="io.ktor.server" level="DEBUG"/>
     <!-- Import loggers configuration from external file -->
     <include file="/mnt/config/logback/loggers-include.xml"/>
 </configuration>


### PR DESCRIPTION
Preserve prefixes from model update, except if it conflicts with flexo prefixes
Guarded patch is updated too since some functions are shared
Model commit's update body isn't being used anywhere, no need to store it right now, find some place else to store if desired in the future