### PR TITLE
Fix/ldp put replace

### DIFF
--- a/src/main/kotlin/org/openmbee/flexo/mms/Layer1Context.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/Layer1Context.kt
@@ -372,7 +372,7 @@ class Layer1Context<TRequestContext: GenericRequest, out TResponseContext: Gener
             "groupId" to groups,
         )
 
-        log("Executing SPARQL Update:\n$sparql")
+        log("Executing SPARQL Update:\n ${if (sparql.length > 10000) "Update String too big to log, truncated:\n" + sparql.substring(0, 10000) else sparql}")
 
         return handleSparqlResponse(defaultHttpClient.post(call.application.quadStoreUpdateUrl) {
             headers {

--- a/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/OrgWrite.kt
+++ b/src/main/kotlin/org/openmbee/flexo/mms/routes/ldp/OrgWrite.kt
@@ -142,6 +142,9 @@ suspend fun <TResponseContext: LdpMutateResponse> LdpDcLayer1Context<TResponseCo
             }
         }
         where {
+            if (replaceExisting) {
+                existingOrg()
+            }
             // assert the required conditions (e.g., access-control, existence, etc.)
             raw(*localConditions.requiredPatterns())
         }

--- a/src/test/kotlin/org/openmbee/flexo/mms/OrgAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/OrgAny.kt
@@ -1,6 +1,7 @@
 package org.openmbee.flexo.mms
 
 import io.ktor.server.testing.*
+import org.apache.jena.rdf.model.ResourceFactory
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
 import org.openmbee.flexo.mms.util.*
@@ -22,6 +23,8 @@ fun TriplesAsserter.validateOrgTriples(
             DCTerms.title exactly orgName.en,
             // MMS.etag exactly createResponse.headers[HttpHeaders.ETag]!!,
             MMS.etag startsWith "",
+            MMS.created startsWith "",
+            MMS.createdBy exactly ResourceFactory.createResource(userIri("root")),
             *extraPatterns.toTypedArray()
         )
     }

--- a/src/test/kotlin/org/openmbee/flexo/mms/OrgLdpDc.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/OrgLdpDc.kt
@@ -22,6 +22,13 @@ class OrgLdpDc : OrgAny() {
                 response shouldHaveStatus HttpStatusCode.BadRequest
             }
 
+            replaceExisting {
+                it includesTriples {
+                    // will error if etag have multiple values or created/createdBy doesn't exist
+                    validateOrgTriples(it, demoOrgId, demoOrgName)
+                }
+            }
+
             read(
                 { createOrg(fooOrgId, fooOrgName) },
                 { createOrg(barOrgId, barOrgName) },

--- a/src/test/kotlin/org/openmbee/flexo/mms/RepoAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/RepoAny.kt
@@ -3,6 +3,7 @@ package org.openmbee.flexo.mms
 import io.kotest.core.test.TestCase
 import io.ktor.http.*
 import io.ktor.server.testing.*
+import org.apache.jena.rdf.model.ResourceFactory
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
 import org.openmbee.flexo.mms.util.*
@@ -19,13 +20,14 @@ fun TriplesAsserter.validateRepoTriples(
 
     // repo triples
     subject(localIri(repoPath)) {
-        includes(
+        exclusivelyHas(
             RDF.type exactly MMS.Repo,
             MMS.id exactly repoId,
             MMS.org exactly localIri(orgPath).iri,
             DCTerms.title exactly repoName.en,
             MMS.etag startsWith "",
             MMS.created startsWith "",
+            MMS.createdBy exactly ResourceFactory.createResource("http://layer1-service/users/root"),
             *extraPatterns.toTypedArray()
         )
     }

--- a/src/test/kotlin/org/openmbee/flexo/mms/RepoAny.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/RepoAny.kt
@@ -27,7 +27,7 @@ fun TriplesAsserter.validateRepoTriples(
             DCTerms.title exactly repoName.en,
             MMS.etag startsWith "",
             MMS.created startsWith "",
-            MMS.createdBy exactly ResourceFactory.createResource("http://layer1-service/users/root"),
+            MMS.createdBy exactly ResourceFactory.createResource(userIri("root")),
             *extraPatterns.toTypedArray()
         )
     }

--- a/src/test/kotlin/org/openmbee/flexo/mms/RepoLdpDc.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/RepoLdpDc.kt
@@ -34,6 +34,15 @@ class RepoLdpDc : RepoAny() {
                 }
             }
 
+            replaceExisting {
+                it includesTriples {
+                    // will error if etag have multiple values or created/createdBy doesn't exist
+                    validateRepoTriples(demoRepoId, demoRepoName, demoOrgPath, listOf(
+                        arbitraryPropertyIri.toPredicate exactly arbitraryPropertyValue,
+                    ))
+                }
+            }
+
             read(
                 { createRepo(demoOrgPath, fooRepoId, fooRepoName) },
                 { createRepo(demoOrgPath, barRepoId, barRepoName) },

--- a/src/test/kotlin/org/openmbee/flexo/mms/util/LinkedDataPlatform.kt
+++ b/src/test/kotlin/org/openmbee/flexo/mms/util/LinkedDataPlatform.kt
@@ -435,6 +435,18 @@ class LinkedDataPlatformDirectContainerTests(
         }
     }
 
+    fun CommonSpec.replaceExisting(validator: ((TestApplicationResponse) -> Unit)) {
+        "PUT $resourcePath - replace resource" {
+            resourceCreator()
+            withTest {
+                httpPut(resourcePath) {
+                    setTurtleBody(validBodyForCreate)
+                }.apply {
+                    validator(response)
+                }
+            }
+        }
+    }
 
     /**
      * Checks that the LDP direct container responds correctly to various patch calls


### PR DESCRIPTION
Fix cases where PUT to replace org or repo kept previous values and added extra values to existing properties
Added created and createdBy properties for org